### PR TITLE
Fix output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Print output to `stdout` instead of `stderr`.
 - Add prototype.
 
 

--- a/cmd/root/output.go
+++ b/cmd/root/output.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -12,7 +13,7 @@ func handleOutput(flag *flag, marshalled []byte) error {
 	force := flag.force
 
 	if output == "" {
-		print(string(marshalled))
+		fmt.Print(string(marshalled))
 		return nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

Previously, we've used `print` to output the results of the command. `print` directs the output to `stderr`, which makes it hard to use the results of the command.

### What is the effect of this change to users?

Users will be able to use the output of `helm-values-gen`, e.g.:
```
diff ./helm/cluster-azure/values.yaml <(helm-values-gen helm/cluster-azure/values.schema.json)
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1983

### What is needed from the reviewers?

An approval :)

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
