### PR TITLE
Fix yaml marshalling breaking long lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Dont add line breaks into long strings in yaml output.
 - Print output to `stdout` instead of `stderr`.
 - Add prototype.
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/imdario/mergo v0.3.13
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/pkg/marshal/yaml.go
+++ b/pkg/marshal/yaml.go
@@ -2,7 +2,7 @@ package marshal
 
 import (
 	"github.com/giantswarm/microerror"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 func ToYaml(data interface{}) ([]byte, error) {

--- a/pkg/marshal/yaml_test.go
+++ b/pkg/marshal/yaml_test.go
@@ -1,0 +1,21 @@
+package marshal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToYamlWithLongStrings(t *testing.T) {
+	data := map[string]interface{}{
+		"test": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbb",
+	}
+	marshalled, err := ToYaml(data)
+	if err != nil {
+		t.Fatalf("Error marshalling to YAML:\n%s", err)
+	}
+	linesSep := "\n"
+	nLines := strings.Count(string(marshalled), linesSep)
+	if nLines != 1 {
+		t.Fatalf("Expected 1 line, got %d. yaml.Marshal() should not split long strings", nLines)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Old versions of `gopkg.in/yaml`, which the current version of `sigs.k8s.io/yaml` seems to use added line breaks to the yaml output if the line is longer than 80 characters. This behavior is unexpected and this PR uses an up to date version of `gopkg.in/yaml` that no longer breaks lines. 

### What is the effect of this change to users?

Users won't see unexpected line breaks in long strings in the yaml output.

### How does it look like?

[old behavior](https://github.com/giantswarm/cluster-azure/pull/80#discussion_r1114051087):
```
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU 
vault-ca@vault.operations.giantswarm.io
```
new behavior:
```
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1983

### What is needed from the reviewers?

Nothing special.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
