### PR TITLE
Fix yaml marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix yaml marshaling.
 - Dont add line breaks into long strings in yaml output.
 - Print output to `stdout` instead of `stderr`.
 - Add prototype.

--- a/pkg/marshal/yaml.go
+++ b/pkg/marshal/yaml.go
@@ -1,14 +1,38 @@
 package marshal
 
 import (
+	"bytes"
+
 	"github.com/giantswarm/microerror"
 	"gopkg.in/yaml.v3"
+	sigsYaml "sigs.k8s.io/yaml"
 )
 
 func ToYaml(data interface{}) ([]byte, error) {
-	marshalled, err := yaml.Marshal(data)
+	convertedData, err := convertJSONNumbers(data)
+	if err != nil {
+		return nil, microerror.Maskf(marshalError, "Error during YAML marshaling:\n%s", err)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	err = enc.Encode(convertedData)
 	if err != nil {
 		return nil, microerror.Maskf(marshalError, "Error marshalling to YAML:\n%s", err)
 	}
+	marshalled := buf.Bytes()
 	return marshalled, nil
+}
+
+// marshals to YAML and unmarshals back to interface{} to convert json.Number appropriately
+func convertJSONNumbers(data interface{}) (interface{}, error) {
+	b, err := sigsYaml.Marshal(data)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	var converted interface{}
+	err = sigsYaml.Unmarshal(b, &converted)
+	return converted, microerror.Mask(err)
+
 }

--- a/pkg/marshal/yaml_test.go
+++ b/pkg/marshal/yaml_test.go
@@ -1,9 +1,81 @@
 package marshal
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestToYaml(t *testing.T) {
+	testCases := []struct {
+		name string
+		data interface{}
+		want string
+	}{
+		{
+			name: "case 0: simple",
+			data: map[string]interface{}{
+				"foo": "bar",
+			},
+			want: "foo: bar\n",
+		},
+		{
+			name: "case 1: long string with possible line break",
+			data: map[string]interface{}{
+				"test": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbb",
+			},
+			want: "test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbb\n",
+		},
+		{
+			name: "case 2: integer",
+			data: map[string]interface{}{
+				"test": 1,
+			},
+			want: "test: 1\n",
+		},
+		{
+			name: "case 3: float",
+			data: map[string]interface{}{
+				"test": 1.1,
+			},
+			want: "test: 1.1\n",
+		},
+		{
+			name: "case 2: json.Number",
+			data: map[string]interface{}{
+				"test": json.Number("1"),
+			},
+			want: "test: 1\n",
+		},
+		{
+			name: "case 5: nested object",
+			data: map[string]interface{}{
+				"test": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: `test:
+  foo: bar
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ToYaml(tc.data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(got) != tc.want {
+				t.Fatalf("unexpected result: %s", cmp.Diff(string(got), tc.want))
+			}
+		})
+	}
+
+}
 
 func TestToYamlWithLongStrings(t *testing.T) {
 	data := map[string]interface{}{


### PR DESCRIPTION
### What does this PR do?

The [last PR](https://github.com/giantswarm/helm-values-gen/pull/3) introduced some unexpected changes in the yaml output.
- indentation was changed to four spaces
- numbers got converted to strings

This PR fixes both problems.

### What is the effect of this change to users?

Users will see two spaces of indentation in the yaml output and numbers will correctly be marshalled to numbers.

### How does it look like?

Before:
```yaml
controlPlane:
    etcdVolumeSizeGB: "10"
    instanceType: Standard_D4s_v3
    oidc:
        caPem: ""
        clientId: ""
        groupsClaim: ""
        issuerUrl: ""
        usernameClaim: ""
    replicas: "3"
    rootVolumeSizeGB: "50"
```

After:
```yaml
controlPlane:
  etcdVolumeSizeGB: 10
  instanceType: Standard_D4s_v3
  oidc:
    caPem: ""
    clientId: ""
    groupsClaim: ""
    issuerUrl: ""
    usernameClaim: ""
  replicas: 3
  rootVolumeSizeGB: 50
```

### Any background context you can provide?

[PR](https://github.com/giantswarm/helm-values-gen/pull/3) that introduced the issue 

### What is needed from the reviewers?

There is still a minor difference in the indentation of arrays compared to the original marshaling (before the PR that introduced the problems.

Originally:
```yaml
machineDeployments:
- customNodeLabels: []
  customNodeTaints: []
  disableHealthCheck: false
  instanceType: Standard_D2s_v3
  name: md00
  replicas: 3
  rootVolumeSizeGB: 50
```

Now:
```yaml
machineDeployments:
  - customNodeLabels: []
    customNodeTaints: []
    disableHealthCheck: false
    instanceType: Standard_D2s_v3
    name: md00
    replicas: 3
    rootVolumeSizeGB: 50
```

I don't see any problems with this. Do you?

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
