### PR TITLE
Add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add version command.
+
 ## [0.1.0] - 2023-02-28
 
 - Fix yaml marshaling.

--- a/cmd/root/command.go
+++ b/cmd/root/command.go
@@ -1,6 +1,10 @@
 package root
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	
+	"github.com/giantswarm/helm-values-gen/pkg/project"
+)
 
 func New() *cobra.Command {
 	flag := &flag{}
@@ -22,6 +26,7 @@ value will be used, if not then this tool won't traverse into the array's items.
 		ArgAliases: []string{"PATH"},
 		RunE:       runner.run,
 		PreRunE:    runner.preRun,
+		Version:    project.Version(),
 	}
 	flag.init(rootCmd)
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,9 @@
+package project
+
+var (
+	version = "0.1.1-dev"
+)
+
+func Version() string {
+	return version
+}


### PR DESCRIPTION
### What does this PR do?

Add the possibility to print out the version with `-v` and `--version`.

### What is the effect of this change to users?

Users can print out the version with with `-v` and `--version`.

### How does it look like?

```
❯ helm-values-gen -v
helm-values-gen version 0.1.1-dev
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2093

### What is needed from the reviewers?

Nothing special.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
