### PR TITLE
Fix `update_action.yaml` workflow

### DIFF
--- a/.github/find_release_pr/.gitignore
+++ b/.github/find_release_pr/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.github/find_release_pr/index.js
+++ b/.github/find_release_pr/index.js
@@ -1,3 +1,5 @@
+// This script searches the current repository for a release PR, extracts the
+// version and branch from it, and sets them as outputs.
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 

--- a/.github/find_release_pr/index.js
+++ b/.github/find_release_pr/index.js
@@ -1,0 +1,87 @@
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+const regex = new RegExp('^Release v((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$', 'gm')
+
+async function main() {
+    try {
+        await mainE();
+    } catch (error) {
+        core.setFailed(error.message);
+    }
+}
+
+async function mainE() {
+    const number = await findReleasePRNumber();
+    const pr = await viewPR(number);
+    core.info('Found release PR: ' + pr.title);
+
+    const version = extractVersionFromTitle(pr.title);
+    core.info('Extracted version: ' + version);
+    const branch = extractBranchFromHeadRefName(pr.headRefName);
+    core.info('Extracted branch: ' + branch);
+
+    core.setOutput('version', version);
+    core.setOutput('branch', branch);
+}
+
+async function findReleasePRNumber() {
+    const { code, output, error } = await gh(['search', 'prs', '--repo', 'giantswarm/helm-values-gen', '--state', 'open', '--json', 'title,number'])
+    if (code != 0) {
+        throw new Error(error);
+    }
+    const prs = JSON.parse(output.join(''));
+    const releasePRs = prs.filter(pr => pr.title.match(regex));
+
+    if (releasePRs.length !== 1) {
+        throw new Error('Unexpected number of release PRs found: ' + releasePRs.length);
+    }
+
+    const releasePR = releasePRs[0];
+    const number = releasePR.number;
+
+    return number;
+}
+
+async function gh(args) {
+    core.info('Running: gh ' + args.join(' '));
+
+    const output = [];
+    const error = [];
+
+    const options = { silent: true }
+    options.listeners = {
+        stdout: (data) => {
+            output.push(data.toString());
+            core.debug(data.toString());
+        },
+        stderr: (data) => {
+            error.push(data.toString());
+            core.debug(data.toString());
+        }
+    };
+    code = await exec.exec('bash', ['-c', 'gh ' + args.join(' ')], options);
+    return { code: code, output, error };
+}
+
+function extractVersionFromTitle(title) {
+    const match = regex.exec(title);
+    const version = match[1];
+    return version;
+}
+
+function extractBranchFromHeadRefName(headRefName) {
+    const branch = headRefName.replace('refs/heads/', '');
+    return branch;
+}
+
+async function viewPR(number) {
+    const { code, output, error } = await gh(['pr', 'view', number, '--json', 'title,headRefName'])
+    if (code != 0) {
+        throw new Error(error);
+    }
+    const pr = JSON.parse(output.join(''));
+    return pr;
+}
+
+main();

--- a/.github/find_release_pr/index.js
+++ b/.github/find_release_pr/index.js
@@ -26,7 +26,7 @@ async function mainE() {
 }
 
 async function findReleasePRNumber() {
-    const { code, output, error } = await gh(['search', 'prs', '--repo', 'giantswarm/helm-values-gen', '--state', 'open', '--json', 'title,number'])
+    const { code, output, error } = await gh(['pr', 'list', '--repo', 'giantswarm/helm-values-gen', '--state', 'open', '--json', 'title,number'])
     if (code != 0) {
         throw new Error(error);
     }

--- a/.github/find_release_pr/package-lock.json
+++ b/.github/find_release_pr/package-lock.json
@@ -1,0 +1,105 @@
+{
+  "name": "find_release_pr",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "find_release_pr",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@actions/exec": "^1.1.1"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
+      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
+      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/.github/find_release_pr/package.json
+++ b/.github/find_release_pr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "find_release_pr",
+  "version": "1.0.0",
+  "description": "",
+  "main": "find_release_branch.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1"
+  }
+}

--- a/.github/workflows/find_release_branch.js
+++ b/.github/workflows/find_release_branch.js
@@ -1,0 +1,5 @@
+const regex = "^Release v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$"
+
+
+
+// gh search prs --repo giantswarm/helm-values-gen --state open --json title,number

--- a/.github/workflows/find_release_branch.js
+++ b/.github/workflows/find_release_branch.js
@@ -1,5 +1,0 @@
-const regex = "^Release v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$"
-
-
-
-// gh search prs --repo giantswarm/helm-values-gen --state open --json title,number

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -42,7 +42,8 @@ jobs:
       - name: "Run local js action"
         id: get_version
         run: node .github/find_release_pr/index.js
-
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   update_version:
     name: Update version in action.yml

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -7,11 +7,8 @@ on:
     workflows: ["Create Release PR"]
     types:
       - completed
-  workflow_dispatch: # for debugging
-  pull_request: # for debugging
-    types: 
-      - opened
-      - reopened
+  push: {}
+
 jobs:
   get_version:
     name: Get version from PR title

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -3,10 +3,37 @@
 
 name: Update action yml
 on:
-  pull_request:
-    types: 
-      - opened
+  workflow_run:
+    workflows: ["Create Release PR"]
+    types:
+      - completed
+  workflow_dispatch: # for debugging
 jobs:
+  get_version_test:
+    name: Get version from PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check gh cli
+        run: gh --version
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: .github/find_release_pr/package-lock.json
+      - name: Install npm packages
+        working-directory: .github/find_release_pr
+        run: "npm ci"
+      # - name: Install GitHub CLI
+      #   run: |
+      #     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+      #     sudo apt-add-repository https://cli.github.com/packages
+      #     sudo apt update
+      #     sudo apt install gh
+      - name: "Run local js action"
+        run: node .github/find_release_pr/index.js
   get_version:
     name: Get version from PR title
     runs-on: ubuntu-latest

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -7,7 +7,6 @@ on:
     workflows: ["Create Release PR"]
     types:
       - completed
-  push: {}
 
 jobs:
   get_version:
@@ -30,12 +29,6 @@ jobs:
       - name: Install npm packages
         working-directory: .github/find_release_pr
         run: "npm ci"
-      # - name: Install GitHub CLI
-      #   run: |
-      #     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-      #     sudo apt-add-repository https://cli.github.com/packages
-      #     sudo apt update
-      #     sudo apt install gh
       - name: "Run local js action"
         id: get_version
         run: node .github/find_release_pr/index.js

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
   workflow_dispatch: # for debugging
+  pull_request: # for debugging
+    types: 
+      - opened
+      - reopened
 jobs:
   get_version_test:
     name: Get version from PR title

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -13,9 +13,12 @@ on:
       - opened
       - reopened
 jobs:
-  get_version_test:
+  get_version:
     name: Get version from PR title
     runs-on: ubuntu-latest
+    outputs: 
+      version: ${{ steps.get_version.outputs.version }}
+      branch: ${{ steps.get_version.outputs.branch }}
     steps:
       - name: Check gh cli
         run: gh --version
@@ -37,28 +40,9 @@ jobs:
       #     sudo apt update
       #     sudo apt install gh
       - name: "Run local js action"
+        id: get_version
         run: node .github/find_release_pr/index.js
-  get_version:
-    name: Get version from PR title
-    runs-on: ubuntu-latest
-    outputs: 
-      version: ${{ steps.regex-match.outputs.group1 }}
-    steps:
-      - name: Run regex match action
-        uses: actions-ecosystem/action-regex-match@v2
-        id: regex-match
-        with:
-          text: ${{ github.event.pull_request.title }}
-          # (modified) official semver regix: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string 
-          regex: '^Release v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$'
-          flags: 'g'
-      - name: Check that the version is defined
-        run: |
-          if [ -z "${{ steps.regex-match.outputs.group1 }}" ]; then
-            echo "No version found"
-          else
-            echo "Version found: ${{ steps.regex-match.outputs.group1 }}"
-          fi
+
 
   update_version:
     name: Update version in action.yml
@@ -69,7 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ needs.get_version.outputs.branch }}
       - name: Update version in action.yml
         uses: mikefarah/yq@v4.31.2
         with:
@@ -85,6 +69,6 @@ jobs:
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-          branch_name: ${{ github.head_ref || github.ref_name }} 
+          branch_name: ${{ needs.get_version.outputs.branch }}
         run: |
           git push "${remote_repo}" "HEAD:${branch_name}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix update action workflow trigger.
+
 ## [0.2.0] - 2023-03-09
 
 - Improve update action workflow.


### PR DESCRIPTION
### What does this PR do?

The `update-action.yaml` workflow, which updates the version of `helm-values-gen` referenced in `actions/ensure-generated/action.yml` was not triggered properly before.
Before this PR the action was triggered every time a new PR was created and it then checked (via the title) whether it is a release PR.  This turned out to not work because PRs created by GitHub actions (like the release PR) can not trigger other GitHub actions.
This PR introduces a new alternative, where the `update-action` workflow is triggered as soon as the "Create Release PR" workflow finishes. This, however, introduced a new challenge, namely getting the new release version and the branch of the release PR. Both are needed to update the referenced version, mentioned above.
To solve this problem, this PR also introduced a javascript script (`.github/find_release_pr/index.js`), that with the help of the GitHub CLI (`gh`) identifies the release PR and retrieves the version from its title, as well as, the source branch of the PR.

### What is the effect of this change to users?

No effect on users.
We, maintainers, won't have to manually update the referenced version in `actions/ensure-generated/action.yml` each time we make a release. 


### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2093

### What is needed from the reviewers?

Testing the new action is not trivial.
To test it I had a release PR open and then triggered this action (e.g. temporarily changing the trigger to `on: push`.
[Here](https://github.com/giantswarm/helm-values-gen/actions/runs/4477514223) you can confirm that the workflow ran successfully.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
