### PR TITLE
Fix module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix module path.
+
 ## [1.0.0] - 2023-03-21
 
 - Fix update action workflow trigger.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/giantswarm/helm-values-gen/v2/cmd/root"
+	"github.com/giantswarm/helm-values-gen/cmd/root"
 )
 
 func Execute() {

--- a/cmd/root/command.go
+++ b/cmd/root/command.go
@@ -3,7 +3,7 @@ package root
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/helm-values-gen/v2/pkg/project"
+	"github.com/giantswarm/helm-values-gen/pkg/project"
 )
 
 func New() *cobra.Command {

--- a/cmd/root/runner.go
+++ b/cmd/root/runner.go
@@ -1,9 +1,9 @@
 package root
 
 import (
-	"github.com/giantswarm/helm-values-gen/v2/pkg/convert"
-	"github.com/giantswarm/helm-values-gen/v2/pkg/jsonschema"
-	"github.com/giantswarm/helm-values-gen/v2/pkg/marshal"
+	"github.com/giantswarm/helm-values-gen/pkg/convert"
+	"github.com/giantswarm/helm-values-gen/pkg/jsonschema"
+	"github.com/giantswarm/helm-values-gen/pkg/marshal"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/helm-values-gen/v2
+module github.com/giantswarm/helm-values-gen
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/giantswarm/helm-values-gen/v2/cmd"
+	"github.com/giantswarm/helm-values-gen/cmd"
 )
 
 func main() {

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -1,7 +1,7 @@
 package convert
 
 import (
-	"github.com/giantswarm/helm-values-gen/v2/pkg/jsonschema"
+	"github.com/giantswarm/helm-values-gen/pkg/jsonschema"
 	"github.com/giantswarm/microerror"
 	"github.com/imdario/mergo"
 )

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/giantswarm/helm-values-gen/v2/pkg/jsonschema"
+	"github.com/giantswarm/helm-values-gen/pkg/jsonschema"
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/yaml"
 )


### PR DESCRIPTION
### What does this PR do?

The "Create Release PR" incorrectly changed the go module path by appending `/v2`. This PR reverts that. 

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
