### PR TITLE
Test new release creation workflow

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -184,13 +184,12 @@ jobs:
           git push "${REMOTE_REPO}" --tags
       - name: Create release
         id: create_gh_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}
-          tag_name: "v${{ needs.gather_facts.outputs.version }}"
-          release_name: "v${{ needs.gather_facts.outputs.version }}"
+          tag: "v${{ needs.gather_facts.outputs.version }}"
 
   ensure_floating_major_version_tags:
     name: Ensure floating major version tags


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29032

This change wants to temporarily update the release creation workflow, which is normally updated through automation, to test the workflow here in a repo with small blast radius.